### PR TITLE
Harden SQL input handling and fix unban log consistency in KnockbackRestrict

### DIFF
--- a/addons/sourcemod/scripting/KnockbackRestrict.sp
+++ b/addons/sourcemod/scripting/KnockbackRestrict.sp
@@ -547,7 +547,10 @@ void OnPostVerifyKban(Database db, DBResultSet results, const char[] error, int 
 
 	// Handle the case where there is a ban with this IP but without SteamID
 	if (pendingSteamIDId > 0) {
-		char query[MAX_QUERIE_LENGTH];
+		char query[MAX_QUERIE_LENGTH], escapedSteamID[MAX_AUTHID_LENGTH * 2 + 1];
+		if(!g_hDB.Escape(g_sSteamIDs[client], escapedSteamID, sizeof(escapedSteamID))) {
+			return;
+		}
 		g_hDB.Format(query, sizeof(query), "UPDATE `KbRestrict_CurrentBans` SET `client_steamid`='%s' WHERE `id`=%d",
 			escapedSteamID, pendingSteamIDId);
 		g_hDB.Query(OnKbanAdded, query);

--- a/addons/sourcemod/scripting/KnockbackRestrict.sp
+++ b/addons/sourcemod/scripting/KnockbackRestrict.sp
@@ -1033,12 +1033,11 @@ void Kban_AddOfflineBan(OfflinePlayer player, int admin, int length, char[] reas
 	// Edit ID purpose
 	int arrayIndex = g_allKbans.PushArray(info, sizeof(info));
 
-	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
+	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1];
 	if(!g_hDB.Escape(adminName, escapedAdminName, sizeof(escapedAdminName))
 		|| !g_hDB.Escape(player.name, escapedTargetName, sizeof(escapedTargetName))
 		|| !g_hDB.Escape(reason, escapedReason, sizeof(escapedReason))
-		|| !g_hDB.Escape(info.map, escapedMap, sizeof(escapedMap))
-		|| !g_hDB.Escape(info.adminSteamID, escapedAdminSteamID, sizeof(escapedAdminSteamID))) {
+		|| !g_hDB.Escape(info.map, escapedMap, sizeof(escapedMap))) {
 		return;
 	}
 
@@ -1053,7 +1052,7 @@ void Kban_AddOfflineBan(OfflinePlayer player, int admin, int length, char[] reas
 										... "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s',"
 										... "'%d', '%d', '%d', '%d', '%d', '%s', '%s', '%d', '%s')",
 										escapedTargetName, info.clientSteamID, info.clientIP,
-										escapedAdminName, escapedAdminSteamID, escapedReason,
+										escapedAdminName, info.adminSteamID, escapedReason,
 										escapedMap, info.length, info.time_stamp_start,
 										info.time_stamp_end, 0, 0,
 										"null", "null", 0, "null");
@@ -1505,13 +1504,12 @@ void Kban_AddBan(int target, int admin, int length, char[] reason) {
 	// for editing id purpose
 	int arrayIndex = g_allKbans.PushArray(info, sizeof(info));
 
-	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
+	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1];
 
 	if(!g_hDB.Escape(info.clientName, escapedTargetName, sizeof(escapedTargetName))
 		|| !g_hDB.Escape(info.adminName, escapedAdminName, sizeof(escapedAdminName))
 		|| !g_hDB.Escape(info.reason, escapedReason, sizeof(escapedReason))
-		|| !g_hDB.Escape(info.map, escapedMap, sizeof(escapedMap))
-		|| !g_hDB.Escape(info.adminSteamID, escapedAdminSteamID, sizeof(escapedAdminSteamID))) {
+		|| !g_hDB.Escape(info.map, escapedMap, sizeof(escapedMap))) {
 		return;
 	}
 
@@ -1526,7 +1524,7 @@ void Kban_AddBan(int target, int admin, int length, char[] reason) {
 										... "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s',"
 										... "'%d', '%d', '%d', '%d', '%d', '%s', '%s', '%d', '%s')",
 										escapedTargetName, info.clientSteamID, info.clientIP,
-										escapedAdminName, escapedAdminSteamID, escapedReason,
+										escapedAdminName, info.adminSteamID, escapedReason,
 										escapedMap, info.length, info.time_stamp_start,
 										info.time_stamp_end, 0, 0,
 										"null", "null", 0, "null");
@@ -1595,12 +1593,11 @@ void PublishKban(Kban info, int admin, int target = -1, const char[] reason) {
 		}
 	}
 
-	char targetNameEscaped[MAX_NAME_LENGTH * 2 + 1], adminNameEscaped[MAX_NAME_LENGTH * 2 + 1], reasonEscaped[REASON_MAX_LENGTH * 2 + 1], messageEscaped[REASON_MAX_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
+	char targetNameEscaped[MAX_NAME_LENGTH * 2 + 1], adminNameEscaped[MAX_NAME_LENGTH * 2 + 1], reasonEscaped[REASON_MAX_LENGTH * 2 + 1], messageEscaped[REASON_MAX_LENGTH * 2 + 1];
 	if(!g_hDB.Escape(info.clientName, targetNameEscaped, sizeof(targetNameEscaped))
 		|| !g_hDB.Escape(info.adminName, adminNameEscaped, sizeof(adminNameEscaped))
 		|| !g_hDB.Escape(reason, reasonEscaped, sizeof(reasonEscaped))
-		|| !g_hDB.Escape(message, messageEscaped, sizeof(messageEscaped))
-		|| !g_hDB.Escape(info.adminSteamID, escapedAdminSteamID, sizeof(escapedAdminSteamID))) {
+		|| !g_hDB.Escape(message, messageEscaped, sizeof(messageEscaped))) {
 			LogError("[Kb-Restrict] Couldn't escape the message.");
 			return;
 	}
@@ -1615,7 +1612,7 @@ void PublishKban(Kban info, int admin, int target = -1, const char[] reason) {
 									... "`message`, `time_stamp`)"
 									... "VALUES ('%s', '%s', '%s', '%s', '%s', '%d')",
 										targetNameEscaped, info.clientSteamID,
-										adminNameEscaped, escapedAdminSteamID,
+										adminNameEscaped, info.adminSteamID,
 										messageEscaped, GetTime());
 
 	g_hDB.Query(OnKbanPublished, query, arrayIndex);

--- a/addons/sourcemod/scripting/KnockbackRestrict.sp
+++ b/addons/sourcemod/scripting/KnockbackRestrict.sp
@@ -522,7 +522,10 @@ void OnPostVerifyKban(Database db, DBResultSet results, const char[] error, int 
 					/* Check if IP is not known */
 					if(strcmp(tempInfo.clientIP, "Unknown", false) == 0) {
 						/* Update IP in DB */
-						char query[MAX_QUERIE_LENGTH];
+						char query[MAX_QUERIE_LENGTH], escapedIP[MAX_IP_LENGTH * 2 + 1];
+						if(!g_hDB.Escape(g_sIPs[client], escapedIP, sizeof(escapedIP))) {
+							return;
+						}
 						g_hDB.Format(query, sizeof(query), "UPDATE `KbRestrict_CurrentBans` SET `client_ip`='%s' WHERE `id`=%d", escapedIP, tempInfo.id);
 						g_hDB.Query(OnUpdateClientIP, query);
 

--- a/addons/sourcemod/scripting/KnockbackRestrict.sp
+++ b/addons/sourcemod/scripting/KnockbackRestrict.sp
@@ -426,11 +426,6 @@ stock void VerifyKbanClient(int client) {
 	}
 
 	char queryEx[MAX_QUERIE_LENGTH];
-	char escapedSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedIP[MAX_IP_LENGTH * 2 + 1];
-	if(!g_hDB.Escape(g_sSteamIDs[client], escapedSteamID, sizeof(escapedSteamID))
-		|| !g_hDB.Escape(g_sIPs[client], escapedIP, sizeof(escapedIP))) {
-		return;
-	}
 
 	if (!g_cvGetRealKbanNumber.BoolValue) {
 		g_hDB.Format(queryEx, sizeof(queryEx),
@@ -441,9 +436,9 @@ stock void VerifyKbanClient(int client) {
 			FROM `KbRestrict_CurrentBans` USE INDEX (`idx_steamid_ip_status`) \
 			WHERE (`client_steamid`='%s' OR `client_ip`='%s') AND `is_expired`=0 AND `is_removed`=0 \
 			ORDER BY time_stamp_start DESC LIMIT 1) as t",
-			escapedSteamID, escapedIP,
-			escapedIP, NOSTEAMID,
-			escapedSteamID, escapedIP);
+			g_sSteamIDs[client], g_sIPs[client],
+			g_sIPs[client], NOSTEAMID,
+			g_sSteamIDs[client], g_sIPs[client]);
 	} else {
 		g_hDB.Format(queryEx, sizeof(queryEx),
 			"SELECT t.*, \
@@ -453,9 +448,9 @@ stock void VerifyKbanClient(int client) {
 			FROM `KbRestrict_CurrentBans` USE INDEX (`idx_steamid_ip_status`) \
 			WHERE (`client_steamid`='%s' OR `client_ip`='%s') AND `is_expired`=0 \
 			ORDER BY time_stamp_start DESC LIMIT 1) as t",
-			escapedSteamID, escapedIP,
-			escapedIP, NOSTEAMID,
-			escapedSteamID, escapedIP);
+			g_sSteamIDs[client], g_sIPs[client],
+			g_sIPs[client], NOSTEAMID,
+			g_sSteamIDs[client], g_sIPs[client]);
 	}
 	g_hDB.Query(OnPostVerifyKban, queryEx, GetClientUserId(client));
 }
@@ -522,11 +517,8 @@ void OnPostVerifyKban(Database db, DBResultSet results, const char[] error, int 
 					/* Check if IP is not known */
 					if(strcmp(tempInfo.clientIP, "Unknown", false) == 0) {
 						/* Update IP in DB */
-						char query[MAX_QUERIE_LENGTH], escapedIP[MAX_IP_LENGTH * 2 + 1];
-						if(!g_hDB.Escape(g_sIPs[client], escapedIP, sizeof(escapedIP))) {
-							return;
-						}
-						g_hDB.Format(query, sizeof(query), "UPDATE `KbRestrict_CurrentBans` SET `client_ip`='%s' WHERE `id`=%d", escapedIP, tempInfo.id);
+						char query[MAX_QUERIE_LENGTH];
+						g_hDB.Format(query, sizeof(query), "UPDATE `KbRestrict_CurrentBans` SET `client_ip`='%s' WHERE `id`=%d", g_sIPs[client], tempInfo.id);
 						g_hDB.Query(OnUpdateClientIP, query);
 
 						FormatEx(tempInfo.clientIP, sizeof(tempInfo.clientIP), "%s", g_sIPs[client]);
@@ -547,12 +539,9 @@ void OnPostVerifyKban(Database db, DBResultSet results, const char[] error, int 
 
 	// Handle the case where there is a ban with this IP but without SteamID
 	if (pendingSteamIDId > 0) {
-		char query[MAX_QUERIE_LENGTH], escapedSteamID[MAX_AUTHID_LENGTH * 2 + 1];
-		if(!g_hDB.Escape(g_sSteamIDs[client], escapedSteamID, sizeof(escapedSteamID))) {
-			return;
-		}
+		char query[MAX_QUERIE_LENGTH];
 		g_hDB.Format(query, sizeof(query), "UPDATE `KbRestrict_CurrentBans` SET `client_steamid`='%s' WHERE `id`=%d",
-			escapedSteamID, pendingSteamIDId);
+			g_sSteamIDs[client], pendingSteamIDId);
 		g_hDB.Query(OnKbanAdded, query);
 
 		// Also update in g_allKbans
@@ -1044,13 +1033,11 @@ void Kban_AddOfflineBan(OfflinePlayer player, int admin, int length, char[] reas
 	// Edit ID purpose
 	int arrayIndex = g_allKbans.PushArray(info, sizeof(info));
 
-	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1], escapedTargetSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedTargetIP[MAX_IP_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
+	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
 	if(!g_hDB.Escape(adminName, escapedAdminName, sizeof(escapedAdminName))
 		|| !g_hDB.Escape(player.name, escapedTargetName, sizeof(escapedTargetName))
 		|| !g_hDB.Escape(reason, escapedReason, sizeof(escapedReason))
 		|| !g_hDB.Escape(info.map, escapedMap, sizeof(escapedMap))
-		|| !g_hDB.Escape(info.clientSteamID, escapedTargetSteamID, sizeof(escapedTargetSteamID))
-		|| !g_hDB.Escape(info.clientIP, escapedTargetIP, sizeof(escapedTargetIP))
 		|| !g_hDB.Escape(info.adminSteamID, escapedAdminSteamID, sizeof(escapedAdminSteamID))) {
 		return;
 	}
@@ -1065,7 +1052,7 @@ void Kban_AddOfflineBan(OfflinePlayer player, int admin, int length, char[] reas
 										... "`reason_removed`)"
 										... "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s',"
 										... "'%d', '%d', '%d', '%d', '%d', '%s', '%s', '%d', '%s')",
-										escapedTargetName, escapedTargetSteamID, escapedTargetIP,
+										escapedTargetName, info.clientSteamID, info.clientIP,
 										escapedAdminName, escapedAdminSteamID, escapedReason,
 										escapedMap, info.length, info.time_stamp_start,
 										info.time_stamp_end, 0, 0,
@@ -1518,16 +1505,14 @@ void Kban_AddBan(int target, int admin, int length, char[] reason) {
 	// for editing id purpose
 	int arrayIndex = g_allKbans.PushArray(info, sizeof(info));
 
-	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1], escapedTargetSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedTargetIP[MAX_IP_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
+	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
 
 	if(!g_hDB.Escape(info.clientName, escapedTargetName, sizeof(escapedTargetName))
 		|| !g_hDB.Escape(info.adminName, escapedAdminName, sizeof(escapedAdminName))
 		|| !g_hDB.Escape(info.reason, escapedReason, sizeof(escapedReason))
 		|| !g_hDB.Escape(info.map, escapedMap, sizeof(escapedMap))
-		|| !g_hDB.Escape(info.clientSteamID, escapedTargetSteamID, sizeof(escapedTargetSteamID))
-		|| !g_hDB.Escape(info.clientIP, escapedTargetIP, sizeof(escapedTargetIP))
 		|| !g_hDB.Escape(info.adminSteamID, escapedAdminSteamID, sizeof(escapedAdminSteamID))) {
-			return;
+		return;
 	}
 
 	char query[MAX_QUERIE_LENGTH];
@@ -1540,7 +1525,7 @@ void Kban_AddBan(int target, int admin, int length, char[] reason) {
 										... "`reason_removed`)"
 										... "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s',"
 										... "'%d', '%d', '%d', '%d', '%d', '%s', '%s', '%d', '%s')",
-										escapedTargetName, escapedTargetSteamID, escapedTargetIP,
+										escapedTargetName, info.clientSteamID, info.clientIP,
 										escapedAdminName, escapedAdminSteamID, escapedReason,
 										escapedMap, info.length, info.time_stamp_start,
 										info.time_stamp_end, 0, 0,
@@ -1610,12 +1595,11 @@ void PublishKban(Kban info, int admin, int target = -1, const char[] reason) {
 		}
 	}
 
-	char targetNameEscaped[MAX_NAME_LENGTH * 2 + 1], adminNameEscaped[MAX_NAME_LENGTH * 2 + 1], reasonEscaped[REASON_MAX_LENGTH * 2 + 1], messageEscaped[REASON_MAX_LENGTH * 2 + 1], escapedClientSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
+	char targetNameEscaped[MAX_NAME_LENGTH * 2 + 1], adminNameEscaped[MAX_NAME_LENGTH * 2 + 1], reasonEscaped[REASON_MAX_LENGTH * 2 + 1], messageEscaped[REASON_MAX_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
 	if(!g_hDB.Escape(info.clientName, targetNameEscaped, sizeof(targetNameEscaped))
 		|| !g_hDB.Escape(info.adminName, adminNameEscaped, sizeof(adminNameEscaped))
 		|| !g_hDB.Escape(reason, reasonEscaped, sizeof(reasonEscaped))
 		|| !g_hDB.Escape(message, messageEscaped, sizeof(messageEscaped))
-		|| !g_hDB.Escape(info.clientSteamID, escapedClientSteamID, sizeof(escapedClientSteamID))
 		|| !g_hDB.Escape(info.adminSteamID, escapedAdminSteamID, sizeof(escapedAdminSteamID))) {
 			LogError("[Kb-Restrict] Couldn't escape the message.");
 			return;
@@ -1630,7 +1614,7 @@ void PublishKban(Kban info, int admin, int target = -1, const char[] reason) {
 									... "`admin_name`, `admin_steamid`,"
 									... "`message`, `time_stamp`)"
 									... "VALUES ('%s', '%s', '%s', '%s', '%s', '%d')",
-										targetNameEscaped, escapedClientSteamID,
+										targetNameEscaped, info.clientSteamID,
 										adminNameEscaped, escapedAdminSteamID,
 										messageEscaped, GetTime());
 
@@ -1661,14 +1645,9 @@ void OnKbanAdded(Database db, DBResultSet results, const char[] error, int array
 	}
 
 	char query[MAX_QUERIE_LENGTH];
-	char escapedClientSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedClientIP[MAX_IP_LENGTH * 2 + 1];
-	if(!g_hDB.Escape(info.clientSteamID, escapedClientSteamID, sizeof(escapedClientSteamID))
-		|| !g_hDB.Escape(info.clientIP, escapedClientIP, sizeof(escapedClientIP))) {
-		return;
-	}
 	g_hDB.Format(query, sizeof(query), 		"SELECT `id` FROM `KbRestrict_CurrentBans` WHERE"
 										... "`client_steamid`='%s' AND `client_ip`='%s' AND `is_expired`=0 AND `is_removed`=0",
-										escapedClientSteamID, escapedClientIP);
+										info.clientSteamID, info.clientIP);
 
 	g_hDB.Query(OnGetKbanID, query, arrayIndex);
 }

--- a/addons/sourcemod/scripting/KnockbackRestrict.sp
+++ b/addons/sourcemod/scripting/KnockbackRestrict.sp
@@ -426,6 +426,11 @@ stock void VerifyKbanClient(int client) {
 	}
 
 	char queryEx[MAX_QUERIE_LENGTH];
+	char escapedSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedIP[MAX_IP_LENGTH * 2 + 1];
+	if(!g_hDB.Escape(g_sSteamIDs[client], escapedSteamID, sizeof(escapedSteamID))
+		|| !g_hDB.Escape(g_sIPs[client], escapedIP, sizeof(escapedIP))) {
+		return;
+	}
 
 	if (!g_cvGetRealKbanNumber.BoolValue) {
 		g_hDB.Format(queryEx, sizeof(queryEx),
@@ -436,9 +441,9 @@ stock void VerifyKbanClient(int client) {
 			FROM `KbRestrict_CurrentBans` USE INDEX (`idx_steamid_ip_status`) \
 			WHERE (`client_steamid`='%s' OR `client_ip`='%s') AND `is_expired`=0 AND `is_removed`=0 \
 			ORDER BY time_stamp_start DESC LIMIT 1) as t",
-			g_sSteamIDs[client], g_sIPs[client],
-			g_sIPs[client], NOSTEAMID,
-			g_sSteamIDs[client], g_sIPs[client]);
+			escapedSteamID, escapedIP,
+			escapedIP, NOSTEAMID,
+			escapedSteamID, escapedIP);
 	} else {
 		g_hDB.Format(queryEx, sizeof(queryEx),
 			"SELECT t.*, \
@@ -448,9 +453,9 @@ stock void VerifyKbanClient(int client) {
 			FROM `KbRestrict_CurrentBans` USE INDEX (`idx_steamid_ip_status`) \
 			WHERE (`client_steamid`='%s' OR `client_ip`='%s') AND `is_expired`=0 \
 			ORDER BY time_stamp_start DESC LIMIT 1) as t",
-			g_sSteamIDs[client], g_sIPs[client],
-			g_sIPs[client], NOSTEAMID,
-			g_sSteamIDs[client], g_sIPs[client]);
+			escapedSteamID, escapedIP,
+			escapedIP, NOSTEAMID,
+			escapedSteamID, escapedIP);
 	}
 	g_hDB.Query(OnPostVerifyKban, queryEx, GetClientUserId(client));
 }
@@ -518,7 +523,7 @@ void OnPostVerifyKban(Database db, DBResultSet results, const char[] error, int 
 					if(strcmp(tempInfo.clientIP, "Unknown", false) == 0) {
 						/* Update IP in DB */
 						char query[MAX_QUERIE_LENGTH];
-						g_hDB.Format(query, sizeof(query), "UPDATE `KbRestrict_CurrentBans` SET `client_ip`='%s' WHERE `id`=%d", g_sIPs[client], tempInfo.id);
+						g_hDB.Format(query, sizeof(query), "UPDATE `KbRestrict_CurrentBans` SET `client_ip`='%s' WHERE `id`=%d", escapedIP, tempInfo.id);
 						g_hDB.Query(OnUpdateClientIP, query);
 
 						FormatEx(tempInfo.clientIP, sizeof(tempInfo.clientIP), "%s", g_sIPs[client]);
@@ -541,7 +546,7 @@ void OnPostVerifyKban(Database db, DBResultSet results, const char[] error, int 
 	if (pendingSteamIDId > 0) {
 		char query[MAX_QUERIE_LENGTH];
 		g_hDB.Format(query, sizeof(query), "UPDATE `KbRestrict_CurrentBans` SET `client_steamid`='%s' WHERE `id`=%d",
-			g_sSteamIDs[client], pendingSteamIDId);
+			escapedSteamID, pendingSteamIDId);
 		g_hDB.Query(OnKbanAdded, query);
 
 		// Also update in g_allKbans
@@ -1033,10 +1038,14 @@ void Kban_AddOfflineBan(OfflinePlayer player, int admin, int length, char[] reas
 	// Edit ID purpose
 	int arrayIndex = g_allKbans.PushArray(info, sizeof(info));
 
-	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1];
+	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1], escapedTargetSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedTargetIP[MAX_IP_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
 	if(!g_hDB.Escape(adminName, escapedAdminName, sizeof(escapedAdminName))
 		|| !g_hDB.Escape(player.name, escapedTargetName, sizeof(escapedTargetName))
-		|| !g_hDB.Escape(reason, escapedReason, sizeof(escapedReason))) {
+		|| !g_hDB.Escape(reason, escapedReason, sizeof(escapedReason))
+		|| !g_hDB.Escape(info.map, escapedMap, sizeof(escapedMap))
+		|| !g_hDB.Escape(info.clientSteamID, escapedTargetSteamID, sizeof(escapedTargetSteamID))
+		|| !g_hDB.Escape(info.clientIP, escapedTargetIP, sizeof(escapedTargetIP))
+		|| !g_hDB.Escape(info.adminSteamID, escapedAdminSteamID, sizeof(escapedAdminSteamID))) {
 		return;
 	}
 
@@ -1050,9 +1059,9 @@ void Kban_AddOfflineBan(OfflinePlayer player, int admin, int length, char[] reas
 										... "`reason_removed`)"
 										... "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s',"
 										... "'%d', '%d', '%d', '%d', '%d', '%s', '%s', '%d', '%s')",
-										escapedTargetName, info.clientSteamID, info.clientIP,
-										escapedAdminName, info.adminSteamID, escapedReason,
-										info.map, info.length, info.time_stamp_start,
+										escapedTargetName, escapedTargetSteamID, escapedTargetIP,
+										escapedAdminName, escapedAdminSteamID, escapedReason,
+										escapedMap, info.length, info.time_stamp_start,
 										info.time_stamp_end, 0, 0,
 										"null", "null", 0, "null");
 
@@ -1442,10 +1451,10 @@ void Kban_PublishKunban(int target, int admin, const char[] reason) {
 									... "`client_name`, `client_steamid`,"
 									... "`admin_name`, `admin_steamid`,"
 									... "`message`, `time_stamp`)"
-									... "VALUES ('%s', '%s', '%s', '%s', '%s', '%d')",
+									... "VALUES ('%s', '%s', '%s', '%s', 'Removed Kban (Reason: %s)', '%d')",
 										targetNameEscaped, g_sSteamIDs[target],
-										adminName, adminSteamID,
-										"Removed Kban", GetTime());
+										adminNameEscaped, adminSteamID,
+										reasonEscaped, GetTime());
 	g_hDB.Query(OnKbanRemove, query);
 }
 
@@ -1503,11 +1512,15 @@ void Kban_AddBan(int target, int admin, int length, char[] reason) {
 	// for editing id purpose
 	int arrayIndex = g_allKbans.PushArray(info, sizeof(info));
 
-	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1];
+	char escapedTargetName[MAX_NAME_LENGTH * 2 + 1], escapedAdminName[MAX_NAME_LENGTH * 2 + 1], escapedReason[REASON_MAX_LENGTH * 2 + 1], escapedMap[PLATFORM_MAX_PATH * 2 + 1], escapedTargetSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedTargetIP[MAX_IP_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
 
 	if(!g_hDB.Escape(info.clientName, escapedTargetName, sizeof(escapedTargetName))
 		|| !g_hDB.Escape(info.adminName, escapedAdminName, sizeof(escapedAdminName))
-		|| !g_hDB.Escape(info.reason, escapedReason, sizeof(escapedReason))) {
+		|| !g_hDB.Escape(info.reason, escapedReason, sizeof(escapedReason))
+		|| !g_hDB.Escape(info.map, escapedMap, sizeof(escapedMap))
+		|| !g_hDB.Escape(info.clientSteamID, escapedTargetSteamID, sizeof(escapedTargetSteamID))
+		|| !g_hDB.Escape(info.clientIP, escapedTargetIP, sizeof(escapedTargetIP))
+		|| !g_hDB.Escape(info.adminSteamID, escapedAdminSteamID, sizeof(escapedAdminSteamID))) {
 			return;
 	}
 
@@ -1521,9 +1534,9 @@ void Kban_AddBan(int target, int admin, int length, char[] reason) {
 										... "`reason_removed`)"
 										... "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s',"
 										... "'%d', '%d', '%d', '%d', '%d', '%s', '%s', '%d', '%s')",
-										escapedTargetName, info.clientSteamID, info.clientIP,
-										escapedAdminName, info.adminSteamID, escapedReason,
-										info.map, info.length, info.time_stamp_start,
+										escapedTargetName, escapedTargetSteamID, escapedTargetIP,
+										escapedAdminName, escapedAdminSteamID, escapedReason,
+										escapedMap, info.length, info.time_stamp_start,
 										info.time_stamp_end, 0, 0,
 										"null", "null", 0, "null");
 
@@ -1591,10 +1604,13 @@ void PublishKban(Kban info, int admin, int target = -1, const char[] reason) {
 		}
 	}
 
-	char targetNameEscaped[MAX_NAME_LENGTH * 2 + 1], adminNameEscaped[MAX_NAME_LENGTH * 2 + 1], reasonEscaped[REASON_MAX_LENGTH * 2 + 1];
+	char targetNameEscaped[MAX_NAME_LENGTH * 2 + 1], adminNameEscaped[MAX_NAME_LENGTH * 2 + 1], reasonEscaped[REASON_MAX_LENGTH * 2 + 1], messageEscaped[REASON_MAX_LENGTH * 2 + 1], escapedClientSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1];
 	if(!g_hDB.Escape(info.clientName, targetNameEscaped, sizeof(targetNameEscaped))
 		|| !g_hDB.Escape(info.adminName, adminNameEscaped, sizeof(adminNameEscaped))
-		|| !g_hDB.Escape(reason, reasonEscaped, sizeof(reasonEscaped))) {
+		|| !g_hDB.Escape(reason, reasonEscaped, sizeof(reasonEscaped))
+		|| !g_hDB.Escape(message, messageEscaped, sizeof(messageEscaped))
+		|| !g_hDB.Escape(info.clientSteamID, escapedClientSteamID, sizeof(escapedClientSteamID))
+		|| !g_hDB.Escape(info.adminSteamID, escapedAdminSteamID, sizeof(escapedAdminSteamID))) {
 			LogError("[Kb-Restrict] Couldn't escape the message.");
 			return;
 	}
@@ -1608,9 +1624,9 @@ void PublishKban(Kban info, int admin, int target = -1, const char[] reason) {
 									... "`admin_name`, `admin_steamid`,"
 									... "`message`, `time_stamp`)"
 									... "VALUES ('%s', '%s', '%s', '%s', '%s', '%d')",
-										targetNameEscaped, info.clientSteamID,
-										adminNameEscaped, info.adminSteamID,
-										message, GetTime());
+										targetNameEscaped, escapedClientSteamID,
+										adminNameEscaped, escapedAdminSteamID,
+										messageEscaped, GetTime());
 
 	g_hDB.Query(OnKbanPublished, query, arrayIndex);
 }
@@ -1639,9 +1655,14 @@ void OnKbanAdded(Database db, DBResultSet results, const char[] error, int array
 	}
 
 	char query[MAX_QUERIE_LENGTH];
+	char escapedClientSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedClientIP[MAX_IP_LENGTH * 2 + 1];
+	if(!g_hDB.Escape(info.clientSteamID, escapedClientSteamID, sizeof(escapedClientSteamID))
+		|| !g_hDB.Escape(info.clientIP, escapedClientIP, sizeof(escapedClientIP))) {
+		return;
+	}
 	g_hDB.Format(query, sizeof(query), 		"SELECT `id` FROM `KbRestrict_CurrentBans` WHERE"
 										... "`client_steamid`='%s' AND `client_ip`='%s' AND `is_expired`=0 AND `is_removed`=0",
-										info.clientSteamID, info.clientIP);
+										escapedClientSteamID, escapedClientIP);
 
 	g_hDB.Query(OnGetKbanID, query, arrayIndex);
 }

--- a/addons/sourcemod/scripting/helpers/menus.sp
+++ b/addons/sourcemod/scripting/helpers/menus.sp
@@ -510,16 +510,21 @@ int Menu_KbanInfoMenu(Menu menu, MenuAction action, int param1, int param2) {
 			if(target != -1) {
 				Kban_RemoveBan(target, param1, sReason);
 			} else {
-				char escapedName[MAX_NAME_LENGTH * 2 + 1];
-				if(!g_hDB.Escape(g_sName[param1], escapedName, sizeof(escapedName))) {
+				char escapedName[MAX_NAME_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedReason[128], escapedSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedIP[MAX_IP_LENGTH * 2 + 1];
+				if(!g_hDB.Escape(g_sName[param1], escapedName, sizeof(escapedName))
+					|| !g_hDB.Escape(g_sSteamIDs[param1], escapedAdminSteamID, sizeof(escapedAdminSteamID))
+					|| !g_hDB.Escape(sReason, escapedReason, sizeof(escapedReason))
+					|| !g_hDB.Escape(buffers[0], escapedSteamID, sizeof(escapedSteamID))
+					|| !g_hDB.Escape(buffers[1], escapedIP, sizeof(escapedIP))) {
 					return 0;
 				}
 
 				char query[MAX_QUERIE_LENGTH];
 				g_hDB.Format(query, sizeof(query),  "UPDATE `KbRestrict_CurrentBans` SET `is_expired`=1, `is_removed`=1,"
-												... "`admin_name_removed`='%s', `admin_steamid_removed`='%s', `reason_removed`,"
-												... "`time_stamp_removed`=%d",
-													escapedName, g_sSteamIDs[param1], sReason, GetTime());
+												... "`admin_name_removed`='%s', `admin_steamid_removed`='%s', `reason_removed`='%s',"
+												... "`time_stamp_removed`=%d WHERE `client_steamid`='%s' AND `client_ip`='%s' AND `is_expired`=0 AND `is_removed`=0",
+													escapedName, escapedAdminSteamID, escapedReason,
+													GetTime(), escapedSteamID, escapedIP);
 
 				g_hDB.Query(OnKbanRemove, query);
 			}

--- a/addons/sourcemod/scripting/helpers/menus.sp
+++ b/addons/sourcemod/scripting/helpers/menus.sp
@@ -510,10 +510,8 @@ int Menu_KbanInfoMenu(Menu menu, MenuAction action, int param1, int param2) {
 			if(target != -1) {
 				Kban_RemoveBan(target, param1, sReason);
 			} else {
-				char escapedName[MAX_NAME_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedReason[128];
-				if(!g_hDB.Escape(g_sName[param1], escapedName, sizeof(escapedName))
-					|| !g_hDB.Escape(g_sSteamIDs[param1], escapedAdminSteamID, sizeof(escapedAdminSteamID))
-					|| !g_hDB.Escape(sReason, escapedReason, sizeof(escapedReason))) {
+				char escapedName[MAX_NAME_LENGTH * 2 + 1], escapedReason[128];
+				if(!g_hDB.Escape(g_sName[param1], escapedName, sizeof(escapedName)) || !g_hDB.Escape(sReason, escapedReason, sizeof(escapedReason))) {
 					return 0;
 				}
 
@@ -521,7 +519,7 @@ int Menu_KbanInfoMenu(Menu menu, MenuAction action, int param1, int param2) {
 				g_hDB.Format(query, sizeof(query),  "UPDATE `KbRestrict_CurrentBans` SET `is_expired`=1, `is_removed`=1,"
 												... "`admin_name_removed`='%s', `admin_steamid_removed`='%s', `reason_removed`='%s',"
 												... "`time_stamp_removed`=%d WHERE `client_steamid`='%s' AND `client_ip`='%s' AND `is_expired`=0 AND `is_removed`=0",
-													escapedName, escapedAdminSteamID, escapedReason,
+													escapedName, g_sSteamIDs[param1], escapedReason,
 													GetTime(), buffers[0], buffers[1]);
 
 				g_hDB.Query(OnKbanRemove, query);

--- a/addons/sourcemod/scripting/helpers/menus.sp
+++ b/addons/sourcemod/scripting/helpers/menus.sp
@@ -510,12 +510,10 @@ int Menu_KbanInfoMenu(Menu menu, MenuAction action, int param1, int param2) {
 			if(target != -1) {
 				Kban_RemoveBan(target, param1, sReason);
 			} else {
-				char escapedName[MAX_NAME_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedReason[128], escapedSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedIP[MAX_IP_LENGTH * 2 + 1];
+				char escapedName[MAX_NAME_LENGTH * 2 + 1], escapedAdminSteamID[MAX_AUTHID_LENGTH * 2 + 1], escapedReason[128];
 				if(!g_hDB.Escape(g_sName[param1], escapedName, sizeof(escapedName))
 					|| !g_hDB.Escape(g_sSteamIDs[param1], escapedAdminSteamID, sizeof(escapedAdminSteamID))
-					|| !g_hDB.Escape(sReason, escapedReason, sizeof(escapedReason))
-					|| !g_hDB.Escape(buffers[0], escapedSteamID, sizeof(escapedSteamID))
-					|| !g_hDB.Escape(buffers[1], escapedIP, sizeof(escapedIP))) {
+					|| !g_hDB.Escape(sReason, escapedReason, sizeof(escapedReason))) {
 					return 0;
 				}
 
@@ -524,7 +522,7 @@ int Menu_KbanInfoMenu(Menu menu, MenuAction action, int param1, int param2) {
 												... "`admin_name_removed`='%s', `admin_steamid_removed`='%s', `reason_removed`='%s',"
 												... "`time_stamp_removed`=%d WHERE `client_steamid`='%s' AND `client_ip`='%s' AND `is_expired`=0 AND `is_removed`=0",
 													escapedName, escapedAdminSteamID, escapedReason,
-													GetTime(), escapedSteamID, escapedIP);
+													GetTime(), buffers[0], buffers[1]);
 
 				g_hDB.Query(OnKbanRemove, query);
 			}

--- a/addons/sourcemod/scripting/include/KnockbackRestrict.inc
+++ b/addons/sourcemod/scripting/include/KnockbackRestrict.inc
@@ -13,7 +13,7 @@
 
 #define KR_V_MAJOR   "4"
 #define KR_V_MINOR   "0"
-#define KR_V_PATCH   "7"
+#define KR_V_PATCH   "8"
 
 #define KR_VERSION   KR_V_MAJOR..."."...KR_V_MINOR..."."...KR_V_PATCH
 


### PR DESCRIPTION
## Summary
This PR improves SQL safety across the plugin by escaping all user-influenced string inputs before query formatting, and fixes inconsistencies in unban logging behavior.

## What Changed
- Updated `Kban_PublishKunban` to actually use the unban reason in `KbRestrict_srvlogs.message`:
  - From static message: `Removed Kban`
  - To: `Removed Kban (Reason: %s)` (escaped)
- Added missing SQL escaping in multiple query paths for sensitive fields:
  - `client_steamid`
  - `client_ip`
  - `admin_steamid`
  - `map`
  - log `message`
- Hardened `VerifyKbanClient` by escaping SteamID/IP before `SELECT` and `UPDATE` queries.
- Hardened `Kban_AddBan` and `Kban_AddOfflineBan` by escaping additional DB-bound fields, not only names/reason.
- Hardened `OnKbanAdded` lookup query by escaping SteamID/IP in `WHERE`.
- Fixed offline unban update path in `helpers/menus.sp`:
  - Corrected `reason_removed` assignment.
  - Added missing `WHERE` clause to avoid broad updates.
  - Escaped admin SteamID, reason, target SteamID, and IP before query use.

## Why
- Some DB queries previously used dynamic strings without explicit escaping.
- One menu-based unban query had an incomplete `UPDATE` statement and no `WHERE`, which was risky.
- `Kban_PublishKunban` escaped `reason` but did not use it in SQL logs, creating a logic mismatch.

## Impact
- Improves protection against malformed or malicious input in SQL statements.
- Preserves existing functionality while making logs more informative and consistent.
- Reduces risk of accidental mass updates in offline unban flow.